### PR TITLE
Enable new linkers (mm.so, n.so) on x86

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -81,15 +81,15 @@ ANDROID_HEADERS_PATH = /usr/include/android
 DEFAULT_CONFIGURATION = \
 	--enable-wayland \
 	--with-android-headers=$(ANDROID_HEADERS_PATH) \
-	--enable-property-cache
+	--enable-property-cache \
+	--enable-experimental
 ARCH_CONFIGURATION =
 
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), armhf))
 ARCH_CONFIGURATION = \
 	--enable-arch=arm \
 	--enable-mali-quirks \
-	--enable-adreno-quirks \
-	--enable-experimental
+	--enable-adreno-quirks
 # We enable the linker selection overrides here as we want to stay
 # with the jb linker on a range of selected production devices to
 # not cause any extra risk for regressions on them. They will
@@ -101,8 +101,7 @@ ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), arm64))
 ARCH_CONFIGURATION = \
 	--enable-arch=arm64 \
 	--enable-mali-quirks \
-	--enable-adreno-quirks \
-	--enable-experimental
+	--enable-adreno-quirks
 endif
 ifeq ($(DEB_HOST_ARCH),$(findstring $(DEB_HOST_ARCH), i386))
 ARCH_CONFIGURATION = \


### PR DESCRIPTION
Required to support Android 7 on x86 devices (e.g. T00F)